### PR TITLE
Null safe fix on serialize and fix emitter on message collector

### DIFF
--- a/libs/constants/collector/message.collector.js
+++ b/libs/constants/collector/message.collector.js
@@ -46,7 +46,7 @@ class MessageCollector extends EventEmitter {
             clearTimeout(this._timeout)
             this._timeout = null
             if (this.client?.ev) {
-                this.client.ev.removeListener('messages.upsert', this.messageHandler)
+                this.client.ev.removeAllListeners('messages.upsert')
             }
         })
     }

--- a/libs/constants/collector/message.collector.js
+++ b/libs/constants/collector/message.collector.js
@@ -42,10 +42,6 @@ class MessageCollector extends EventEmitter {
         this.messageHandler = this.messageHandler.bind(this)
         this.client.ev.on('messages.upsert', this.messageHandler)
 
-        this.on('end', () => {
-            clearTimeout(this._timeout)
-            this._timeout = null
-        })
     }
 
     /**
@@ -78,7 +74,10 @@ class MessageCollector extends EventEmitter {
      * @param { string } reason
      */
     stop(reason) {
+        clearTimeout(this._timeout);
+        this._timeout = null;
         this.emit('end', reason)
+        this.client.ev.off('messages.upsert', this.messageHandler);
     }
 }
 

--- a/libs/constants/collector/message.collector.js
+++ b/libs/constants/collector/message.collector.js
@@ -45,9 +45,6 @@ class MessageCollector extends EventEmitter {
         this.on('end', () => {
             clearTimeout(this._timeout)
             this._timeout = null
-            if (this.client?.ev) {
-                this.client.ev.removeAllListeners('messages.upsert')
-            }
         })
     }
 

--- a/libs/utils/serialize/serialize.util.js
+++ b/libs/utils/serialize/serialize.util.js
@@ -29,7 +29,7 @@ const serialize = async (msg, client) => {
     }
     m.pushName = msg.pushName
     m.body = msg.message?.conversation || msg.message[m.type]?.text || msg.message[m.type]?.caption || null
-    if (m.body[1] === ' ') {
+    if (m.body?.[1] === ' ') {
         m.body = m.body.replace(' ', '')
     }
     m.responseId = msg.message?.listResponseMessage?.singleSelectReply?.selectedRowId || msg.message?.buttonsResponseMessage?.selectedButtonId || msg.message?.templateButtonReplyMessage?.selectedId || null


### PR DESCRIPTION
- Removing ``on end`` event on constructor, moving to stop, this will fix collector on keep responding even after the ``end`` event emitted
- Add null safe on serialize while parsing body message