### PR TITLE
Fix reply from groupOnly

### DIFF
--- a/libs/handlers/message/index.js
+++ b/libs/handlers/message/index.js
@@ -76,7 +76,7 @@ module.exports = async (client, { messages, type }) => {
         }
 
         if (getCommand.groupOnly && !msg.isGroup) {
-            return msg.reply(i18n.__('message.private_only'))
+            return msg.reply(i18n.__('message.group_only'))
         }
 
         if (


### PR DESCRIPTION
Instead of using `'message.private_only'` its better to use `'message.group_only'`

Signed-off-by: Ihya Fauzi <git@ihya.dev>